### PR TITLE
[ArtNet] Identify events

### DIFF
--- a/examples/ESP-DMX/ESP-DMX.ino
+++ b/examples/ESP-DMX/ESP-DMX.ino
@@ -207,6 +207,19 @@ void artIpProgReceived(uint8_t cmd, IPAddress addr, IPAddress subnet) {
 }
 
 /*
+  Indicator was request by ArtAddress packet
+*/
+void artIndicatorReceived(bool normal, bool mute, bool locate) {
+    if (normal) {
+        Serial.println("Normal mode");
+    } else if (mute) {
+        Serial.println("Mute mode");
+    } else if (locate) {
+        Serial.println("Locate mode");
+    }
+}
+
+/*
   DMX input callback function sets number of slots received by ESP8266DMX
 */
 
@@ -438,6 +451,7 @@ void setup() {
   artNetInterface->setUniverse(DMXWiFiConfig.artnetPortAddress());	//setUniverse for LXArtNet class sets complete Port-Address
   artNetInterface->setArtAddressReceivedCallback(&artAddressReceived);
   artNetInterface->setArtIpProgReceivedCallback(&artIpProgReceived);
+  artNetInterface->setArtIndicatorReceivedCallback(&artIndicatorReceived);
   if ( rdm_enabled ) {
     artNetInterface->setArtTodRequestCallback(&artTodRequestReceived);
     artNetInterface->setArtRDMCallback(&artRDMReceived);

--- a/examples/ESP32-DMX_rdm/ESP32-DMX_rdm.ino
+++ b/examples/ESP32-DMX_rdm/ESP32-DMX_rdm.ino
@@ -198,6 +198,19 @@ void artIpProgReceived(uint8_t cmd, IPAddress addr, IPAddress subnet) {
 }
 
 /*
+  Indicator was requested by ArtAddress packet
+*/
+void artIndicatorReceived(bool normal, bool mute, bool locate) {
+    if (normal) {
+        Serial.println("Normal mode");
+    } else if (mute) {
+        Serial.println("Mute mode");
+    } else if (locate) {
+        Serial.println("Locate mode");
+    }
+}
+
+/*
   DMX input callback function sets number of slots received by ESP32DMX
 */
 
@@ -450,6 +463,7 @@ void setup() {
   artNetInterface->setArtIpProgReceivedCallback(&artIpProgReceived);
   artNetInterface->setArtTodRequestCallback(&artTodRequestReceived);
   artNetInterface->setArtRDMCallback(&artRDMReceived);
+  artNetInterface->setArtIndicatorReceivedCallback(&artIndicatorReceived);
   char* nn = DMXWiFiConfig.nodeName();
   if ( nn[0] != 0 ) {
     strcpy(artNetInterface->longName(), nn);

--- a/src/LXWiFiArtNet.cpp
+++ b/src/LXWiFiArtNet.cpp
@@ -555,6 +555,10 @@ void LXWiFiArtNet::setArtAddressReceivedCallback(ArtNetReceiveCallback callback)
 	_artaddress_receive_callback = callback;
 }
 
+void LXWiFiArtNet::setArtIndicatorReceivedCallback(ArtNetIndicatorCallback callback) {
+    _art_indicator_callback = callback;
+}
+
 void LXWiFiArtNet::setArtTodRequestCallback(ArtNetDataRecvCallback callback) {
 	_art_tod_req_callback = callback;
 }
@@ -623,6 +627,21 @@ uint16_t LXWiFiArtNet::parse_art_address( UDP* wUDP ) {
 	   		}
 	   	}
 	   	break;
+        case 0x02:
+ 	      if ( _art_indicator_callback != NULL ) {
+ 				_art_indicator_callback(true, false, false);
+ 			}
+			break;
+        case 0x03:
+ 	      if ( _art_indicator_callback != NULL ) {
+ 				_art_indicator_callback(false, true, false);
+ 			}
+ 			break;
+        case 0x04:
+ 	      if ( _art_indicator_callback != NULL ) {
+ 				_art_indicator_callback(false, false, true);
+ 			}
+ 			break;
 	   case 0x90:	//clear buffer
 	   	clearDMXOutput();
 	   	return ARTNET_ART_DMX;	// return ARTNET_ART_DMX so function calling readPacket

--- a/src/LXWiFiArtNet.h
+++ b/src/LXWiFiArtNet.h
@@ -51,6 +51,7 @@
 typedef void (*ArtNetReceiveCallback)(void);
 typedef void (*ArtNetDataRecvCallback)(uint8_t* pdata);
 typedef void (*ArtIpProgRecvCallback)(uint8_t cmd, IPAddress ipaddr, IPAddress subnet);
+typedef void (*ArtNetIndicatorCallback)(bool normal, bool mute, bool locate);
 
 /*!
 *  @class LXWiFiArtNet
@@ -309,7 +310,13 @@ class LXWiFiArtNet : public LXDMXWiFi {
  *             when an ArtAddress packet is received
 */
    void setArtAddressReceivedCallback(ArtNetReceiveCallback callback);
-   
+
+/*!
+* @brief Function called when ArtAddress packet is received
+* @discussion Sets a pointer to a function that is called
+*             when an ArtAddress packet is received
+*/
+  void setArtIndicatorReceivedCallback(ArtNetIndicatorCallback callback);
 /*!
  * @brief function callback when ArtTODRequest is received
  * @discussion callback pointer is to integer
@@ -430,7 +437,11 @@ class LXWiFiArtNet : public LXDMXWiFi {
     * @brief Pointer to art address received callback function
    */
   	ArtNetReceiveCallback _artaddress_receive_callback;
-  	
+
+    /*!
+    * @brief Pointer to Art-Net identify callback function
+   */
+  	ArtNetIndicatorCallback _art_indicator_callback;
   	/*!
     * @brief Pointer to art tod request callback
    */


### PR DESCRIPTION
This allows to register for incoming indentify events through ArtAddress packages.
Tested on an ESP32 and DMX-Workshop.

Let me know if you prefer an ENUM instead of 3 bools!