### PR TITLE
Set input/output mode

### DIFF
--- a/examples/ESP32-DMX_rdm/ESP32-DMX_rdm.ino
+++ b/examples/ESP32-DMX_rdm/ESP32-DMX_rdm.ino
@@ -495,10 +495,12 @@ void setup() {
     }
     aUDP.begin(artNetInterface->dmxPort());
     artNetInterface->send_art_poll_reply(&aUDP, ARTPOLL_OUTPUT_MODE);
+	artNetInterface->setMode(ARTPOLL_OUTPUT_MODE);
     Serial.print("udp started listening,");
   } else {
     aUDP.begin(artNetInterface->dmxPort());
     artNetInterface->send_art_poll_reply(&aUDP, ARTPOLL_INPUT_MODE);
+	artNetInterface->setMode(ARTPOLL_INPUT_MODE);
   }
   
   

--- a/src/LXWiFiArtNet.cpp
+++ b/src/LXWiFiArtNet.cpp
@@ -146,6 +146,14 @@ void LXWiFiArtNet::setNetAddress   ( uint8_t u ) {
 	}
 }
 
+void LXWiFiArtNet::setMode   ( uint8_t mode ) {
+	_mode = mode;
+}
+
+uint8_t LXWiFiArtNet::getMode   ( void ) {
+	return _mode;
+}
+
 int  LXWiFiArtNet::numberOfSlots ( void ) {
 	return _dmx_slots;
 }
@@ -331,13 +339,13 @@ uint16_t LXWiFiArtNet::readArtNetPacketContents ( UDP* wUDP, uint16_t packetSize
 		case ARTNET_ART_ADDRESS:
 			if (( packetSize >= 107 ) && ( _packet_buffer[11] >= 14 )) {  //protocol version [10] hi byte [11] lo byte
 				opcode = parse_art_address( wUDP );
-				send_art_poll_reply( wUDP, ARTPOLL_OUTPUT_MODE );
+				send_art_poll_reply( wUDP, _mode );
 			}
 			break;
 		case ARTNET_ART_POLL:
 			if (( packetSize >= 14 ) && ( _packet_buffer[11] >= 14 )) {
 			    if ( _poll_reply_enabled ) {
-					send_art_poll_reply( wUDP, ARTPOLL_OUTPUT_MODE );
+					send_art_poll_reply( wUDP, _mode );
 				}
 			}
 			break;
@@ -389,7 +397,7 @@ uint16_t LXWiFiArtNet::readArtPollPacketContents ( UDP* wUDP, uint16_t packetSiz
 		case ARTNET_ART_POLL:
 			if (( packetSize >= 14 ) && ( _packet_buffer[11] >= 14 )) {
 			    if ( _poll_reply_enabled ) {
-					send_art_poll_reply( wUDP, ARTPOLL_INPUT_MODE );
+					send_art_poll_reply( wUDP, _mode );
 				}
 			}
 			break;

--- a/src/LXWiFiArtNet.h
+++ b/src/LXWiFiArtNet.h
@@ -147,6 +147,19 @@ class LXWiFiArtNet : public LXDMXWiFi {
 * @param s subnet 0-16 + flag 0x80
 */
    void    setNetAddress   ( uint8_t u );
+   
+/*!
+* @brief set the mode of this node.
+* @discussion This mode is primarily used by send_art_poll_reply().
+* @param mode ARTPOLL_OUTPUT_MODE or ARTPOLL_INPUT_MODE
+*/
+   void    setMode   ( uint8_t mode );
+   
+/*!
+* @brief get the mode of this node.
+* @discussion This method is primarily used by send_art_poll_reply().
+*/
+   uint8_t getMode   ( void );
 
  /*!
  * @brief number of slots (aka addresses or channels)
@@ -416,6 +429,9 @@ class LXWiFiArtNet : public LXDMXWiFi {
   	uint16_t   _poll_reply_counter;
 /// enable flag for sending poll replies
     uint8_t    _poll_reply_enabled;	
+	
+/// Output mode of this note, either ARTPOLL_OUTPUT_MODE or ARTPOLL_INPUT_MODE
+    uint8_t    _mode = ARTPOLL_OUTPUT_MODE;	
 
 /// address included in poll reply 	
   	IPAddress _my_address;


### PR DESCRIPTION
This allows you to define the mode of a node by calling
`artNetInterface->setMode(ARTPOLL_OUTPUT_MODE);`
or
`artNetInterface->setMode(ARTPOLL_INPUT_MODE);`

I implemented this because all ArtPollReplies were using hardcoded `ARTPOLL_OUTPUT_MODE` when not called manually by the user.