### PR TITLE
Adjust loop range for clearing reply buffer

### DIFF
--- a/src/LXWiFiArtNet.cpp
+++ b/src/LXWiFiArtNet.cpp
@@ -478,8 +478,8 @@ void LXWiFiArtNet::send_art_poll_reply( UDP* wUDP, uint8_t mode ) {
   if ( _poll_reply_counter > 9999 ) {
   	 _poll_reply_counter = 0;
   }
-  for (int k=108; k<172; k++) {
-  	_reply_buffer[k] = 0;			// zero status string
+  for (int k=26; k<172; k++) {
+  	_reply_buffer[k] = 0;			// zero short name, long name and status string
   }
   sprintf((char*)&_reply_buffer[108], "#0001 [%04d] ", _poll_reply_counter);
   


### PR DESCRIPTION
Remove trailing stray characters from long name after node name change (OUT-RDM in the below example).

```
0000   ff ff ff ff ff ff f8 b3 b7 8c 35 22 08 00 45 00   ..........5"..E.
0010   01 0c 00 0c 00 00 ff 11 35 d1 c0 a8 01 b4 c0 a8   ........5.......
0020   01 ff 19 36 19 36 00 f8 d2 0a 41 72 74 2d 4e 65   ...6.6....Art-Ne
0030   74 00 00 21 c0 a8 01 b4 36 19 00 00 00 00 12 51   t..!....6......Q
0040   00 22 78 6c 45 53 50 2d 44 4d 58 00 00 00 00 00   ."xlESP-DMX.....
0050   00 00 00 00 00 00 4f 55 54 2d 52 44 4d 00 64 65   ......OUT-RDM.de
0060   68 65 69 6e 74 7a 64 65 73 69 67 6e 2e 65 73 70   heintzdesign.esp
0070   2d 64 6d 78 00 00 00 00 00 00 00 00 00 00 00 00   -dmx............
0080   00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00   ................
0090   00 00 00 00 00 00 23 30 30 30 31 20 5b 30 30 30   ......#0001 [000
00a0   32 5d 20 49 64 6c 65 3a 20 6e 6f 20 41 72 74 44   2] Idle: no ArtD
00b0   4d 58 00 00 00 00 00 00 00 00 00 00 00 00 00 00   MX..............
00c0   00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00   ................
00d0   00 00 00 00 00 00 00 01 80 00 00 00 00 00 00 00   ................
00e0   80 00 00 00 00 00 00 00 01 00 00 00 00 00 00 00   ................
00f0   00 00 00 00 00 00 00 00 00 00 00 00 00 01 1e 00   ................
0100   00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00   ................
0110   00 00 00 00 00 00 00 00 00 00                     ..........

```